### PR TITLE
Enhance getCsv method to provide processing status and improve error …

### DIFF
--- a/csv_handeling/src/main/java/com/duft/csv_handeling/RestController/InputCsvController.java
+++ b/csv_handeling/src/main/java/com/duft/csv_handeling/RestController/InputCsvController.java
@@ -92,41 +92,47 @@ public class InputCsvController {
 
     @GetMapping(value="/getcsv/{trackID}")
     public ResponseEntity<Resource> getCsv(@PathVariable String trackID){
-        if(!service.checkProcessedInd(trackID).equals("Success")){
-            return ResponseEntity.notFound().build();
-        }else{
-            
-        
+        String status = service.checkProcessedInd(trackID);
+        if (!"Success".equals(status)) {
+            // Respond with a message if still processing
+            return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .header(HttpHeaders.CONTENT_TYPE, "text/plain")
+                .body(new InputStreamResource(
+                    new java.io.ByteArrayInputStream(
+                        ("Still processing. Current status: " + status).getBytes()
+                    )
+                ));
+        } else {
+            try {
+                File csvFile = service.fetchDataforCSV(trackID); // Call your service method
 
-        try {
-        File csvFile = service.fetchDataforCSV(trackID); // Call your service method
+                if (csvFile == null || !csvFile.exists()) {
+                    // Handle case where file generation failed or file doesn't exist
+                    return ResponseEntity.notFound().build();
+                }
 
-        if (csvFile == null || !csvFile.exists()) {
-            // Handle case where file generation failed or file doesn't exist
-            return ResponseEntity.notFound().build();
+                InputStreamResource resource = new InputStreamResource(new FileInputStream(csvFile));
+
+                HttpHeaders headers = new HttpHeaders();
+                headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + csvFile.getName() + "\"");
+                headers.add(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate");
+                headers.add(HttpHeaders.PRAGMA, "no-cache");
+                headers.add(HttpHeaders.EXPIRES, "0");
+
+                return ResponseEntity.ok()
+                        .headers(headers)
+                        .contentLength(csvFile.length())
+                        .contentType(MediaType.parseMediaType("text/csv"))
+                        .body(resource);
+
+            } catch (IOException e) {
+                // Log error
+                // e.printStackTrace(); 
+                return ResponseEntity.internalServerError().body(null); // Or a more specific error response
+            }
         }
-
-        InputStreamResource resource = new InputStreamResource(new FileInputStream(csvFile));
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.add(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + csvFile.getName() + "\"");
-        headers.add(HttpHeaders.CACHE_CONTROL, "no-cache, no-store, must-revalidate");
-        headers.add(HttpHeaders.PRAGMA, "no-cache");
-        headers.add(HttpHeaders.EXPIRES, "0");
-
-        return ResponseEntity.ok()
-                .headers(headers)
-                .contentLength(csvFile.length())
-                .contentType(MediaType.parseMediaType("text/csv"))
-                .body(resource);
-
-    } catch (IOException e) {
-        // Log error
-        // e.printStackTrace(); 
-        return ResponseEntity.internalServerError().body(null); // Or a more specific error response
-    
     }
-    }   
-}
 
 }
+

--- a/csv_handeling/src/main/java/com/duft/csv_handeling/RestController/InputCsvController.java
+++ b/csv_handeling/src/main/java/com/duft/csv_handeling/RestController/InputCsvController.java
@@ -8,6 +8,7 @@ package com.duft.csv_handeling.RestController;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 // import java.io.InputStream;
@@ -100,7 +101,7 @@ public class InputCsvController {
                 .header(HttpHeaders.CONTENT_TYPE, "text/plain")
                 .body(new InputStreamResource(
                     new java.io.ByteArrayInputStream(
-                        ("Still processing. Current status: " + status).getBytes()
+                        ("Still processing. Current status: " + status).getBytes(StandardCharsets.UTF_8)
                     )
                 ));
         } else {


### PR DESCRIPTION
This pull request introduces improvements to the `getCsv` method in the `InputCsvController` class to enhance error handling and provide better feedback when a CSV file is still being processed. The most important changes include returning a more informative response when the processing status is not "Success" and ensuring proper HTTP status codes and headers are used.

Enhancements to error handling and feedback:

* [`csv_handeling/src/main/java/com/duft/csv_handeling/RestController/InputCsvController.java`](diffhunk://#diff-4cd57e901129ee364e33c5f2c609c9329e0445687418d73658fdc5dce936983dL95-L100): Modified the `getCsv` method to return an HTTP 202 Accepted status with a message indicating the current processing status when the CSV file is not yet ready. The response now includes the `Content-Type` header set to `text/plain` and uses an `InputStreamResource` for the message body.
* [`csv_handeling/src/main/java/com/duft/csv_handeling/RestController/InputCsvController.java`](diffhunk://#diff-4cd57e901129ee364e33c5f2c609c9329e0445687418d73658fdc5dce936983dL127-R138): Ensured proper cleanup of unnecessary blank lines and improved the error response consistency by returning `ResponseEntity.internalServerError()` for exceptions.…handling